### PR TITLE
Make the symbolic likelihood more customizeable

### DIFF
--- a/calibr8/core.py
+++ b/calibr8/core.py
@@ -17,7 +17,7 @@ import typing
 from . import utils
 
 
-__version__ = '6.0.2'
+__version__ = '6.0.3'
 _log = logging.getLogger('calibr8')
 
 

--- a/calibr8/tests.py
+++ b/calibr8/tests.py
@@ -702,7 +702,15 @@ class TestBasePolynomialModelT:
         # create a pymc3 model using the calibration model
         with pymc3.Model() as pmodel:
             x_hat = pymc3.Uniform('x_hat', lower=0, upper=10, shape=x_true.shape, transform=None)
-            L = cmodel.loglikelihood(x=x_hat, y=y_obs, replicate_id='A01', dependent_key='A')
+
+            with pytest.raises(ValueError, match="`name` must be specified"):
+                cmodel.loglikelihood(x=x_hat, y=y_obs)
+
+            with pytest.warns(DeprecationWarning, match="Use `name` instead"):
+                L = cmodel.loglikelihood(x=x_hat, y=y_obs, replicate_id='A01', dependent_key='A')
+                assert isinstance(L, tt.TensorVariable)
+
+            L = cmodel.loglikelihood(x=x_hat, y=y_obs, name='L_A01_A')
             assert isinstance(L, tt.TensorVariable)
         
         # compare the two loglikelihood computation methods


### PR DESCRIPTION
This PR adds a new `name` kwarg to the `loglikelihood` function, replacing `replicate_id` and `dependent_key`.
Furthermore it forwards additional kwargs, for example `dims` to the PyMC3 distribution.

This way one can named dimensions, resulting in much nicer `pm.model_to_graphviz` plots with PyMC3 version 4:
![grafik](https://user-images.githubusercontent.com/5894642/126377206-c410d9e8-6f48-4b40-83a9-362797e04991.png)


Closes https://jugit.fz-juelich.de/IBG-1/micropro/calibr8/-/issues/48