### PR TITLE
Fix timezone bug in timestamps

### DIFF
--- a/calibr8/core.py
+++ b/calibr8/core.py
@@ -16,7 +16,7 @@ import typing
 from . import utils
 
 
-__version__ = '6.1.0'
+__version__ = '6.1.1
 _log = logging.getLogger('calibr8')
 
 

--- a/calibr8/core.py
+++ b/calibr8/core.py
@@ -16,7 +16,7 @@ import typing
 from . import utils
 
 
-__version__ = '6.1.1
+__version__ = '6.1.1'
 _log = logging.getLogger('calibr8')
 
 

--- a/calibr8/core.py
+++ b/calibr8/core.py
@@ -257,7 +257,7 @@ class CalibrationModel:
     def theta_fitted(self, value: typing.Optional[typing.Sequence[float]]):
         if value is not None:
             self.__theta_fitted = tuple(value)
-            self.__theta_timestamp = datetime.datetime.utcnow().astimezone(datetime.timezone.utc).replace(microsecond=0)
+            self.__theta_timestamp = datetime.datetime.now().astimezone(datetime.timezone.utc).replace(microsecond=0)
         else:
             self.__theta_fitted = None
             self.__theta_timestamp = None


### PR DESCRIPTION
The previous `.utcnow().astimezone(utc)` resulted in a duplicate conversions and ultimately timestamps that were shifted too much.

Credits to @lhelleckes for the discovery!

(Squash please.)