### PR TITLE
Refactor `CalibrationModel` towards concurrent univariate/multivariate compatibility

### DIFF
--- a/calibr8/__init__.py
+++ b/calibr8/__init__.py
@@ -6,6 +6,8 @@ from .contrib.base import (
 )
 from .core import (
     CalibrationModel,
+    InferenceResult,
+    UnivariateInferenceResult,
     NumericPosterior,
     __version__,
     asymmetric_logistic,

--- a/calibr8/core.py
+++ b/calibr8/core.py
@@ -365,7 +365,7 @@ class CalibrationModel:
         # TODO: create a smart x-vector from the CDF with varying stepsize
 
         if ci_prob != 1:
-            if not (0 < ci_prob <= 1):
+            if not isinstance(ci_prob, (int, float)) or not (0 < ci_prob <= 1):
                 raise ValueError(f'Unexpected `ci_prob` value of {ci_prob}. Expected float in interval (0, 1].')
 
             # determine the interval bounds from the high-resolution CDF

--- a/calibr8/tests.py
+++ b/calibr8/tests.py
@@ -59,6 +59,32 @@ class _TestLogIndependentLogisticModel(calibr8.BaseLogIndependentAsymmetricLogis
         super().__init__(independent_key='I', dependent_key='D', scale_degree=scale_degree)
 
 
+class TestInferenceResult:
+    def test_warnings(self):
+        with pytest.warns(DeprecationWarning, match="was renamed"):
+            arr = numpy.arange(10)
+            pst = calibr8.NumericPosterior(
+                0.5,
+                eti_x=arr+0.1, eti_pdf=arr+0.2, eti_prob=0.3,
+                hdi_x=arr+0.4, hdi_pdf=arr+0.5, hdi_prob=0.6,
+            )
+        # Directly forwarded
+        assert isinstance(pst, calibr8.InferenceResult)
+        assert isinstance(pst, calibr8.UnivariateInferenceResult)
+        numpy.testing.assert_array_equal(pst.eti_x, arr+0.1)
+        numpy.testing.assert_array_equal(pst.eti_pdf, arr+0.2)
+        assert pst.eti_prob == 0.3
+        numpy.testing.assert_array_equal(pst.hdi_x, arr+0.4)
+        numpy.testing.assert_array_equal(pst.hdi_pdf, arr+0.5)
+        assert pst.hdi_prob == 0.6
+        # Derived properties
+        assert pst.eti_lower == 0.1
+        assert pst.eti_upper == 9.1
+        assert pst.hdi_lower == 0.4
+        assert pst.hdi_upper == 9.4
+        pass
+
+
 class TestBasicCalibrationModel:
     def test_init(self):
         em = _TestModel('I', 'D', theta_names=tuple('c,d,e'.split(',')))

--- a/calibr8/tests.py
+++ b/calibr8/tests.py
@@ -100,14 +100,15 @@ class TestBasicCalibrationModel:
         x = numpy.array([1,2,3])
         y = numpy.array([4,5,6])
         cmodel = _TestModel()
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(NotImplementedError, match="predict_dependent function"):
             _ = cmodel.predict_dependent(x)
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(NotImplementedError, match="predict_independent function"):
             _ = cmodel.predict_independent(x)
-        with pytest.raises(NotImplementedError):
-            _ = cmodel.infer_independent(y, lower=0, upper=10, steps=10, ci_prob=None)
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(NotImplementedError, match="loglikelihood function"):
             _ = cmodel.loglikelihood(y=y, x=x, theta=[1,2,3])
+        with pytest.raises(ValueError, match=r"Unexpected `ci_prob`"):
+            cmodel.loglikelihood = lambda x, y, theta: 1
+            _ = cmodel.infer_independent(y, lower=0, upper=10, steps=10, ci_prob=None)
         pass
 
     def test_save_and_load_version_check(self):

--- a/calibr8/tests.py
+++ b/calibr8/tests.py
@@ -135,6 +135,9 @@ class TestBasicCalibrationModel:
         with pytest.raises(ValueError, match=r"Unexpected `ci_prob`"):
             cmodel.loglikelihood = lambda x, y, theta: 1
             _ = cmodel.infer_independent(y, lower=0, upper=10, steps=10, ci_prob=None)
+        with pytest.raises(NotImplementedError, match="seems to be multivariate"):
+            cmodel.ndim = 3
+            cmodel.infer_independent(2, lower=0, upper=5)
         pass
 
     def test_save_and_load_version_check(self):


### PR DESCRIPTION
+ `CalibrationModel.ndim` attribute was added
+ `infer_independent` logic was extracted into a local function, paving the way for future multivariate `infer_independent` implementations.
+ Some exception tests were made more accurate (matching messages) and a typing bug that was found through that was fixed.
+ `NumericPosterior` was deprecated/renamed to `UnivariateInferenceResult`, inheriting from a superclass `InferenceResult` whoose signature is compatible with arbitrary dimensionality.