### PR TITLE
Generalize inheritance and composition of model classes

### DIFF
--- a/calibr8/__init__.py
+++ b/calibr8/__init__.py
@@ -14,6 +14,8 @@ from .contrib.base import (
 from .core import (
     CalibrationModel,
     DistributionMixin,
+    ContinuousMultivariateModel,
+    ContinuousUnivariateModel,
     InferenceResult,
     ContinuousMultivariateInference,
     ContinuousUnivariateInference,

--- a/calibr8/__init__.py
+++ b/calibr8/__init__.py
@@ -15,8 +15,8 @@ from .core import (
     CalibrationModel,
     DistributionMixin,
     InferenceResult,
-    UnivariateInferenceResult,
-    NumericPosterior,
+    ContinuousMultivariateInference,
+    ContinuousUnivariateInference,
     __version__,
     asymmetric_logistic,
     inverse_asymmetric_logistic,
@@ -53,7 +53,21 @@ class ErrorModel(CalibrationModel):
         import warnings
 
         warnings.warn(
-            "The `ErrorModel` class was renamed to `CalibrationModel`. It will be removed in a future release.",
+            "The `ErrorModel` class was renamed to `CalibrationModel`."
+            " It will be removed in a future release.",
+            DeprecationWarning,
+        )
+        super().__init__(*args, **kwargs)
+
+
+class NumericPosterior(ContinuousUnivariateInference):
+    """Deprecated alias for ContinuousUnivariateInference"""
+    def __init__(self, *args, **kwargs) -> None:
+        import warnings
+
+        warnings.warn(
+            "The `NumericPosterior` class was renamed to `ContinuousUnivariateInference`."
+            " It will be removed in a future release.",
             DeprecationWarning,
         )
         super().__init__(*args, **kwargs)

--- a/calibr8/contrib/base.py
+++ b/calibr8/contrib/base.py
@@ -8,7 +8,7 @@ from . import noise
 from .. import core
 
 
-class BaseModelT(core.CalibrationModel, noise.StudentTNoise):
+class BaseModelT(core.ContinuousUnivariateModel, noise.StudentTNoise):
     pass
 
 


### PR DESCRIPTION
This PR refactors the model classes such ultimately code duplication is reduced.

The full reasoning behind this inheritance/composition design is [described in a new documentation page](https://github.com/JuBiotech/calibr8/blob/generalize-inheritance/docs/source/calibr8_inheritance.md).

## Changes
__Docs__ (done with #14)
* [x] Sphinx was configured to also render Markdown pages.
* [x] A Markdown document explaining the model classes, inheritance and distribution/noisemodel mixins was added.

__Utils__ (done with #14)
* [x] The `HAS_PYMC` constant is now exposed as `calibr8.HAS_PYMC`. And the `pm` module may be accessed via `calibr8.utils.pm`.

__Generalization of noise model__ (see #16)
* [x] Implement `calibr8.core.DistributionMixin` and a few `calibr8.*Noise` classes.
* [x] Update inheritance of existing contrib models to use mixins.
* [x] Refactor `BaseModelT.loglikelihood` to be distribution-agnostic.
* [x] Move `BaseModelT.loglikelihood` → `CalibrationModel.loglikelihood`.
* [x] Refactor `(log)likelihood` to slice correctly independent of `ndim(x)`.

__Inference type and dimensionality__
* [x] Split `InferenceResult` into subclasses.
* [x] Introduce `ContinuousUnivariateModel` and `ContinuousMultivariateModel` model subclasses with `infer_independent` implementations.
* [x] Update contrib models to inherit from model subclasses.

__Tests__ (see #17)
+ [x] Close multiple tests coverage gaps & fix some bugs in the test code.
+ [x] Reorganize the test suite to correspond to the class hierarchy.
+ Add x- & y-parameterized shape broadcasting tests for the log-likelihood implementation. (deferred to #15)

__Addition of examples__ (deferred to follow-up)
* Univariate, continuous with Laplace noise
* Univariate, discrete with Poisson noise
* Bivarite, continuous with Normal noise
