### PR TITLE
Close coverage gaps and validate `theta_fitted` on assignment

### DIFF
--- a/calibr8/contrib/base.py
+++ b/calibr8/contrib/base.py
@@ -132,7 +132,7 @@ class BasePolynomialModelT(BaseModelT):
             may be used to set the names of the model parameters
         """
         if mu_degree == 0:
-            raise Exception('0-degree (constant) mu calibration models are useless.')
+            raise ValueError("0-degree (constant) mu calibration models are useless.")
         self.mu_degree = mu_degree
         self.scale_degree = scale_degree
         if theta_names is None:

--- a/calibr8/core.py
+++ b/calibr8/core.py
@@ -416,6 +416,11 @@ class CalibrationModel:
     @theta_fitted.setter
     def theta_fitted(self, value: typing.Optional[typing.Sequence[float]]):
         if value is not None:
+            if numpy.shape(value) != numpy.shape(self.theta_names):
+                raise ValueError(
+                    f"The number of parameters ({len(value)}) "
+                    f"does not match the number of parameter names ({len(self.theta_names)})."
+                )
             self.__theta_fitted = tuple(value)
             self.__theta_timestamp = datetime.datetime.now().astimezone(datetime.timezone.utc).replace(microsecond=0)
         else:

--- a/calibr8/core.py
+++ b/calibr8/core.py
@@ -202,7 +202,7 @@ def _get_hdi(
     guess_upper: float,
     *,
     history: typing.Optional[typing.DefaultDict[str, typing.List]]=None
-) -> typing.Tuple[float]:
+) -> typing.Tuple[float, float]:
     """ Find the highest density interval (HDI) corresponding to a certain credible interval probability level.
 
     Parameters
@@ -257,10 +257,15 @@ def _get_hdi(
             history["L"].append(L)
         return L
 
+    initial_guess = [guess_lower, guess_upper - guess_lower]
+    if not numpy.isfinite(hdi_objective(initial_guess)):
+        # Bad initial guess. Reset to the outer limimts.
+        initial_guess = [x_cdf[0], x_cdf[-1] - x_cdf[0]]
+
     fit = scipy.optimize.fmin(
         hdi_objective,
         # parametrize as b=a+d
-        x0=[guess_lower, guess_upper - guess_lower],
+        x0=initial_guess,
         xtol=numpy.ptp(x_cdf) / len(x_cdf),
         disp=False
     )

--- a/calibr8/tests.py
+++ b/calibr8/tests.py
@@ -121,20 +121,18 @@ class TestBasicCalibrationModel:
         pass
 
     def test_exceptions(self):
-        independent = 'X'
-        dependent = 'BS'
         x = numpy.array([1,2,3])
         y = numpy.array([4,5,6])
         cmodel = _TestModel()
         with pytest.raises(NotImplementedError, match="predict_dependent function"):
-            _ = cmodel.predict_dependent(x)
+            cmodel.predict_dependent(x)
         with pytest.raises(NotImplementedError, match="predict_independent function"):
-            _ = cmodel.predict_independent(x)
+            cmodel.predict_independent(x)
         with pytest.raises(NotImplementedError, match="loglikelihood function"):
-            _ = cmodel.loglikelihood(y=y, x=x, theta=[1,2,3])
+            cmodel.loglikelihood(y=y, x=x, theta=[1, 2, 3])
         with pytest.raises(ValueError, match=r"Unexpected `ci_prob`"):
             cmodel.loglikelihood = lambda x, y, theta: 1
-            _ = cmodel.infer_independent(y, lower=0, upper=10, steps=10, ci_prob=None)
+            cmodel.infer_independent(y, lower=0, upper=10, steps=10, ci_prob=None)
         with pytest.raises(NotImplementedError, match="seems to be multivariate"):
             cmodel.ndim = 3
             cmodel.infer_independent(2, lower=0, upper=5)
@@ -207,6 +205,16 @@ class TestBasicCalibrationModel:
         assert em_loaded.theta_timestamp == theta_timestamp
         numpy.testing.assert_array_equal(em_loaded.cal_independent, em.cal_independent)
         numpy.testing.assert_array_equal(em_loaded.cal_dependent, em.cal_dependent)
+        pass
+
+    def test_objective(self):
+        cm = _TestPolynomialModel(mu_degree=1, scale_degree=0)
+        calX = numpy.linspace(1, 10, 5)
+        calY = 0.3 + calX * 0.5
+        theta = [0.3, 0.5, 1]
+        obj_min = cm.objective(calX, calY, minimize=True)
+        obj_max = cm.objective(calX, calY, minimize=False)
+        assert -obj_max(theta) == obj_min(theta)
         pass
 
 


### PR DESCRIPTION
This PR increases overall test coverage and adds a validation of `theta` shape on assignment of `theta_fitted`.

Many tests had to be updated because they assigned a vector of incorrect length.