### PR TITLE
Generalize `plot_model`

### DIFF
--- a/calibr8/__init__.py
+++ b/calibr8/__init__.py
@@ -46,8 +46,7 @@ from .utils import (
     HAS_PYMC,
     istensor,
     plot_model,
-    plot_norm_band,
-    plot_t_band,
+    plot_continuous_band,
 )
 
 

--- a/calibr8/__init__.py
+++ b/calibr8/__init__.py
@@ -46,6 +46,8 @@ from .utils import (
     HAS_PYMC,
     istensor,
     plot_model,
+    plot_t_band,
+    plot_norm_band,
     plot_continuous_band,
 )
 

--- a/calibr8/core.py
+++ b/calibr8/core.py
@@ -19,7 +19,7 @@ from . import utils
 from . utils import pm
 
 
-__version__ = '6.2.1'
+__version__ = '6.3.0'
 _log = logging.getLogger('calibr8')
 
 

--- a/calibr8/tests.py
+++ b/calibr8/tests.py
@@ -90,6 +90,20 @@ class TestDeprecatedClasses:
                 hdi_x=arr*1.1+0.4, hdi_pdf=arr+0.5, hdi_prob=0.6,
             )
         pass
+    
+    def test_warns_plot_t_band(self):
+        _, ax = pyplot.subplots()
+
+        with pytest.warns(DeprecationWarning, match="`plot_t_band` is substituted"):
+            calibr8.utils.plot_t_band(ax=ax, independent=[1,2,3], mu=[3,4,5], scale=[6,7,8], df=1)
+        pass
+
+    def test_warns_plot_norm_band(self):
+        _, ax = pyplot.subplots()
+        
+        with pytest.warns(DeprecationWarning, match="`plot_norm_band` is substituted"):
+            calibr8.utils.plot_norm_band(ax=ax, independent=[1,2,3], mu=[3,4,5], scale=[6,7,8])
+        pass
 
 
 class TestInferenceResult:

--- a/calibr8/utils.py
+++ b/calibr8/utils.py
@@ -227,7 +227,8 @@ def plot_continuous_band(ax, independent, model, residual_type: typing.Optional[
     artists : list of matplotlib.Artist
         the created artists (1x Line2D, 6x PolyCollection (alternating plot & legend))
     """
-    assert hasattr(model.scipy_dist, "ppf"), "Only Scipy distributions with a ppf method can be used for the continuous likelihood bands."
+    if not hasattr(model.scipy_dist, "ppf"):
+        raise ValueError("Only Scipy distributions with a ppf method can be used for the continuous likelihood bands.")
     params =  list(model.predict_dependent(independent))
     if residual_type:
         artists = ax.plot(independent, numpy.repeat(0, len(independent)), color='green')

--- a/calibr8/utils.py
+++ b/calibr8/utils.py
@@ -380,12 +380,13 @@ def plot_model(
     # ======= Left =======
     # Untransformed, outer range
     ax = axs[0]
-    plot_t_band(
-        ax,
-        xband,
-        *model.predict_dependent(xband),
-        residual_type=None
-    )
+    if hasattr(model.scipy_dist, "ppf"):
+        plot_continuous_band(
+            ax,
+            xband,
+            model,
+            residual_type=None,
+        )
     ax.scatter(X, Y)
     ax.set(
         ylabel=model.dependent_key,
@@ -395,12 +396,13 @@ def plot_model(
     # ======= Center =======
     # Transformed if possible, outer range
     ax = axs[1]
-    plot_t_band(
-        ax,
-        xband,
-        *model.predict_dependent(xband),
-        residual_type=None
-    )
+    if hasattr(model.scipy_dist, "ppf"):
+        plot_continuous_band(
+            ax,
+            xband,
+            model,
+            residual_type=None,
+        )
     ax.scatter(X, Y)
     ax.set(
         xlabel=model.independent_key,
@@ -414,12 +416,13 @@ def plot_model(
         xresiduals = numpy.exp(numpy.linspace(numpy.log(min(X)), numpy.log(max(X)), 300))
     else:
         xresiduals = numpy.linspace(min(X), max(X), 300)
-    plot_t_band(
-        ax,
-        xresiduals,
-        *model.predict_dependent(xresiduals),
-        residual_type=residual_type
-    )
+    if hasattr(model.scipy_dist, "ppf"):
+        plot_continuous_band(
+            ax,
+            xresiduals,
+            model,
+            residual_type=residual_type,
+        )
 
     if residual_type == 'relative':
         ax.scatter(X, (Y - model.predict_dependent(X)[0]) / model.predict_dependent(X)[0])

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ fastprogress
 matplotlib
 # Pin upper version because of Thano-PyMC compatibility
 numpy<1.22
-scipy
+# Pin SciPy until pymc>=4.0.0b is released
+scipy<1.8.0


### PR DESCRIPTION
As requested in #21, `plot_t_band` is no longer used as a default for plotting a `CalibrationModel` . Instead, the following was implemented:

- All continuous functions are plotted using the `ppf` method of the Scipy distribution. Using the `to_scipy` method of `DistributionMixin` and allowing usage of args in `plot_model`, new distrubtions are compatible.
- In case no ppf is available, no band is plotted, but the `plot_model` function can still be used.
- In the future, further cases for discrete distributions can be appended.