### PR TITLE
Adapt release to latest version automatically

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,4 @@ myst-parser
 numpydoc
 nbsphinx
 nbsphinx_link
+calibr8

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,4 +4,3 @@ myst-parser
 numpydoc
 nbsphinx
 nbsphinx_link
-calibr8

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,6 +14,7 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 import sphinx_rtd_theme
+from calibr8 import __version__
 
 # -- Project information -----------------------------------------------------
 
@@ -22,7 +23,7 @@ copyright = '2020, Michael Osthege, Laura Helleckes'
 author = 'Michael Osthege, Laura Helleckes'
 
 # The full version, including alpha/beta/rc tags
-release = '5.0.0'
+release = __version__
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,14 +2,14 @@ Welcome to the ``calibr8`` documentation!
 =========================================
 
 .. image:: https://img.shields.io/badge/code%20on-Github-lightgrey
-    :target: https://github.com/michaelosthege/calibr8
+    :target: https://github.com/JuBiotech/calibr8
 
 .. image:: https://zenodo.org/badge/306862348.svg
    :target: https://zenodo.org/badge/latestdoi/306862348
 
 With ``calibr8`` we take a fresh perspective on calibration modeling.
 
-You can download the latest version from `GitHub <https://github.com/michaelosthege/calibr8>`_ or install it via ``pip install calibr8``.
+You can download the latest version from `GitHub <https://github.com/JuBiotech/calibr8>`_ or install it via ``pip install calibr8``.
 
 In the following chapters, we introduce the terminology, basic concepts and most important features.
 


### PR DESCRIPTION
- Fixed a bug that pointed to old repo
- Import calibr8 and use the version number from the package