### PR TITLE
Unpin NumPy and SciPy versions

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -40,7 +40,7 @@ jobs:
       run: |
         pip uninstall -y pymc
         pip uninstall -y aesara
-        pip install "pymc3>=3.11.5,<4"
+        pip install "pymc3>=3.11.5,<4" "numpy<1.22"
         pip install pygmo
     - name: Test with PyMC3 and PyGMO
       run: |

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -40,7 +40,7 @@ jobs:
       run: |
         pip uninstall -y pymc
         pip uninstall -y aesara
-        pip install "pymc3>=3.11.2,<4"
+        pip install "pymc3>=3.11.5,<4"
         pip install pygmo
     - name: Test with PyMC3 and PyGMO
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         pip uninstall -y pymc
         pip uninstall -y aesara
-        pip install "pymc3>=3.11.5,<4"
+        pip install "pymc3>=3.11.5,<4" "numpy<1.22"
         pip install pygmo
     - name: Test with PyMC3 and PyGMO
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         pip uninstall -y pymc
         pip uninstall -y aesara
-        pip install "pymc3>=3.11.2,<4"
+        pip install "pymc3>=3.11.5,<4"
         pip install pygmo
     - name: Test with PyMC3 and PyGMO
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 fastprogress
 matplotlib
-# Pin upper version because of Thano-PyMC compatibility
-numpy<1.22
-# Pin SciPy until pymc>=4.0.0b is released
-scipy<1.8.0
+numpy
+scipy


### PR DESCRIPTION
[PyMC v3.11.5](https://github.com/pymc-devs/pymc/blob/v3.11.5/RELEASE-NOTES.md#pymc-3115-14-march-2022) now pins the SciPy upper limit itself, but it looks like the NumPy 1.22 compatibility hotfix no longer works.

With these changes we're only pinning the version in the CI pipeline.