### PR TITLE
Enabling default solver termination statement +  model saving fix

### DIFF
--- a/calibr8/core.py
+++ b/calibr8/core.py
@@ -678,7 +678,7 @@ class CalibrationModel(DistributionMixin):
         # assign additional attributes (check keys for backwards compatibility)
         obj.theta_bounds = tuple(map(tuple, data["theta_bounds"])) if "theta_bounds" in data else None
         obj.theta_guess = (
-            tuple(data["theta_guess"]) if "theta_guess" in data and data.get("theta_guess") != None else None
+            tuple(data["theta_guess"]) if "theta_guess" in data and data.get("theta_guess") is not None else None
         )
         obj.__theta_fitted = tuple(data["theta_fitted"]) if "theta_fitted" in data else None
         obj.__theta_timestamp = utils.parse_datetime(data.get("theta_timestamp", None))

--- a/calibr8/core.py
+++ b/calibr8/core.py
@@ -619,7 +619,7 @@ class CalibrationModel(DistributionMixin):
             model_type=".".join([self.__module__, self.__class__.__qualname__]),
             theta_names=tuple(self.theta_names),
             theta_bounds=tuple(self.theta_bounds),
-            theta_guess=tuple(self.theta_guess) if self.theta_guess is not None else {},
+            theta_guess=tuple(self.theta_guess) if self.theta_guess is not None else None,
             theta_fitted=self.theta_fitted,
             theta_timestamp=utils.format_datetime(self.theta_timestamp),
             independent_key=self.independent_key,
@@ -677,7 +677,9 @@ class CalibrationModel(DistributionMixin):
 
         # assign additional attributes (check keys for backwards compatibility)
         obj.theta_bounds = tuple(map(tuple, data["theta_bounds"])) if "theta_bounds" in data else None
-        obj.theta_guess = tuple(data["theta_guess"]) if "theta_guess" in data else None
+        obj.theta_guess = (
+            tuple(data["theta_guess"]) if "theta_guess" in data and data.get("theta_guess") != None else None
+        )
         obj.__theta_fitted = tuple(data["theta_fitted"]) if "theta_fitted" in data else None
         obj.__theta_timestamp = utils.parse_datetime(data.get("theta_timestamp", None))
         obj.cal_independent = numpy.array(data["cal_independent"]) if "cal_independent" in data else None

--- a/calibr8/core.py
+++ b/calibr8/core.py
@@ -619,7 +619,7 @@ class CalibrationModel(DistributionMixin):
             model_type=".".join([self.__module__, self.__class__.__qualname__]),
             theta_names=tuple(self.theta_names),
             theta_bounds=tuple(self.theta_bounds),
-            theta_guess=tuple(self.theta_guess),
+            theta_guess=tuple(self.theta_guess) if self.theta_guess is not None else {},
             theta_fitted=self.theta_fitted,
             theta_timestamp=utils.format_datetime(self.theta_timestamp),
             independent_key=self.independent_key,

--- a/calibr8/core.py
+++ b/calibr8/core.py
@@ -678,7 +678,9 @@ class CalibrationModel(DistributionMixin):
         # assign additional attributes (check keys for backwards compatibility)
         obj.theta_bounds = tuple(map(tuple, data["theta_bounds"])) if "theta_bounds" in data else None
         obj.theta_guess = (
-            tuple(data["theta_guess"]) if "theta_guess" in data and data.get("theta_guess") is not None else None
+            tuple(data["theta_guess"])
+            if "theta_guess" in data and data.get("theta_guess") is not None
+            else None
         )
         obj.__theta_fitted = tuple(data["theta_fitted"]) if "theta_fitted" in data else None
         obj.__theta_timestamp = utils.parse_datetime(data.get("theta_timestamp", None))

--- a/calibr8/optimization.py
+++ b/calibr8/optimization.py
@@ -247,6 +247,8 @@ def fit_scipy_global(
     if not fit.success or bound_hit:
         _log.warning(f"Fit of {type(model).__name__} has failed:")
         _log.warning(fit)
+    else:
+        _log.warning(fit)
     model.theta_bounds = theta_bounds
     model.theta_fitted = fit.x
     model.cal_independent = numpy.array(independent)

--- a/calibr8/optimization.py
+++ b/calibr8/optimization.py
@@ -237,7 +237,6 @@ def fit_scipy_global(
         bounds=theta_bounds,
         callback=lambda x, f, context: history.append((x, f, context)),
         maxiter=maxiter,
-        **minimizer_kwargs,
     )
 
     # check for fit success
@@ -246,8 +245,6 @@ def fit_scipy_global(
 
     if not fit.success or bound_hit:
         _log.warning(f"Fit of {type(model).__name__} has failed:")
-        _log.warning(fit)
-    else:
         _log.warning(fit)
     model.theta_bounds = theta_bounds
     model.theta_fitted = fit.x

--- a/calibr8/tests.py
+++ b/calibr8/tests.py
@@ -359,6 +359,33 @@ class TestBaseCalibrationModel:
         numpy.testing.assert_array_equal(em_loaded.cal_dependent, em.cal_dependent)
         pass
 
+    @pytest.mark.parametrize("ndim", [1, 2, 3])
+    def test_save_and_load_attributes_wo_guess(self, ndim):
+        shape = tuple(3 + numpy.arange(ndim))
+        assert len(shape) == ndim
+
+        em = _TestModel()
+        em.theta_fitted = (1, 2, 3)
+        theta_timestamp = em.theta_timestamp
+        em.theta_bounds = ((None, None), (0, 5), (0, 10))
+        em.cal_independent = numpy.random.uniform(0, 10, size=shape)
+        em.cal_dependent = numpy.random.normal(size=len(em.cal_independent))
+
+        # save and load
+        em.save("save_load_test.json")
+        em_loaded = _TestModel.load("save_load_test.json")
+
+        assert isinstance(em_loaded, _TestModel)
+        assert em_loaded.independent_key == em.independent_key
+        assert em_loaded.dependent_key == em.dependent_key
+        assert em_loaded.theta_bounds == em.theta_bounds
+        assert em_loaded.theta_fitted == em.theta_fitted
+        assert em_loaded.theta_timestamp is not None
+        assert em_loaded.theta_timestamp == theta_timestamp
+        numpy.testing.assert_array_equal(em_loaded.cal_independent, em.cal_independent)
+        numpy.testing.assert_array_equal(em_loaded.cal_dependent, em.cal_dependent)
+        pass
+
     def test_objective(self):
         cm = _TestPolynomialModel(mu_degree=1, scale_degree=0)
         calX = numpy.linspace(1, 10, 5)


### PR DESCRIPTION
Adding default solver termination statement output for fit_scipy_global().  
Removing requirement of theta_guess for saving models.

Fixes #56 
