### PR TITLE
Only check model class names for matches

### DIFF
--- a/calibr8/core.py
+++ b/calibr8/core.py
@@ -662,11 +662,10 @@ class CalibrationModel(DistributionMixin):
             pass
 
         # create model instance
-        cls_type = f"{cls.__module__}.{cls.__name__}"
         json_type = data["model_type"]
-        if cls_type.split(".")[-1] not in json_type:
+        if cls.__name__ not in json_type:
             raise utils.CompatibilityException(
-                f"The model type from the JSON file ({json_type}) does not match this class ({cls_type})."
+                f"The model type from the JSON file ({json_type}) does not match this class ({cls.__name__})."
             )
         obj = cls()
 

--- a/calibr8/core.py
+++ b/calibr8/core.py
@@ -664,7 +664,7 @@ class CalibrationModel(DistributionMixin):
         # create model instance
         cls_type = f"{cls.__module__}.{cls.__name__}"
         json_type = data["model_type"]
-        if json_type != cls_type:
+        if cls_type.split(".")[-1] not in json_type:
             raise utils.CompatibilityException(
                 f"The model type from the JSON file ({json_type}) does not match this class ({cls_type})."
             )


### PR DESCRIPTION
Instead of the entire import path, which often changes when moving models between projects, or when running `multiprocessing` stuff.