### PR TITLE
Increment required/tested Python versions

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.10"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -36,7 +36,6 @@ jobs:
         pytest --cov=./calibr8 --cov-append --cov-report xml --cov-report term-missing calibr8
     - name: Upload coverage
       uses: codecov/codecov-action@v4
-      if: matrix.python-version == 3.8
       with:
         file: ./coverage.xml
     - name: Test Wheel install and import

--- a/calibr8/core.py
+++ b/calibr8/core.py
@@ -19,7 +19,7 @@ import scipy
 from . import utils
 from .utils import DistributionType, pm
 
-__version__ = "7.1.2"
+__version__ = "7.2.0"
 _log = logging.getLogger("calibr8")
 
 

--- a/setup.py
+++ b/setup.py
@@ -62,9 +62,9 @@ setuptools.setup(
     classifiers=[
         "Programming Language :: Python",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "License :: OSI Approved :: GNU Affero General Public License v3",
         "Intended Audience :: Science/Research",
         "Topic :: Scientific/Engineering",
@@ -75,5 +75,5 @@ setuptools.setup(
         "calibr8": package_files(str(pathlib.Path(pathlib.Path(__file__).parent, "calibr8").absolute()))
     },
     include_package_data=True,
-    python_requires=">=3.6",
+    python_requires=">=3.10",
 )


### PR DESCRIPTION
Our CI pipelines were starting to fail from incompatibilities of our dependencies.

PyMC already requires Python >=3.10 so I think we should do the same.