### PR TITLE
Test with PyMC v6, drop Python 3.11

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -32,7 +32,7 @@ jobs:
         pytest -v --cov=./calibr8 --cov-append --cov-report xml --cov-report term-missing calibr8
     - name: Install and test with PyMC v5
       run: |
-        pip install "pymc>=5.0.0"
+        pip install "pymc>=6.0.0"
         pytest -v --cov=./calibr8 --cov-append --cov-report xml --cov-report term-missing calibr8
     - name: Upload coverage
       uses: codecov/codecov-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         pytest --cov=./calibr8 --cov-append --cov-report xml --cov-report term-missing calibr8
     - name: Install and test with PyMC v5
       run: |
-        pip install "pymc>=5.0.0"
+        pip install "pymc>=6.0.0"
         pytest --cov=./calibr8 --cov-append --cov-report xml --cov-report term-missing calibr8
     - name: Build package
       run: |

--- a/calibr8/test_all.py
+++ b/calibr8/test_all.py
@@ -1006,18 +1006,17 @@ class TestModelFunctions:
 class TestSymbolicModelFunctions:
     def _check_numpy_backend_equivalence(self, function, theta):
         # make sure that test value computation is turned off (PyMC likes to turn it on)
-        with config.change_flags(compute_test_value="off"):
-            # create computation graph
-            x = at.vector("x", dtype=config.floatX)
-            y = function(x, theta)
-            assert isinstance(y, at.TensorVariable)
+        # create computation graph
+        x = at.vector("x", dtype=config.floatX)
+        y = function(x, theta)
+        assert isinstance(y, at.TensorVariable)
 
-            # compile PyTensor function
-            f = backend.function([x], [y])
+        # compile PyTensor function
+        f = backend.function([x], [y])
 
-            # check equivalence of numpy and PyTensor backend computation
-            x_test = [1, 2, 4]
-            numpy.testing.assert_almost_equal(f(x_test)[0], function(x_test, theta))
+        # check equivalence of numpy and PyTensor backend computation
+        x_test = [1, 2, 4]
+        numpy.testing.assert_almost_equal(f(x_test)[0], function(x_test, theta))
         return
 
     def test_logistic(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "calibr8"
-version = "7.2.0"
+version = "7.3.0"
 description = "Toolbox for non-linear calibration modeling."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -16,7 +16,6 @@ authors = [
 classifiers = [
     "Programming Language :: Python",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",


### PR DESCRIPTION
* Python 3.11 dropped from testing, because it's (close to) EOL and no longer supported by recent PyTensor/PyMC versions
* PyTensor/PyMC v6 compatibility fixed (only test changes needed)